### PR TITLE
Adding organisation type information into JWT token

### DIFF
--- a/Backend/Backend/Common/Utilities/JwtUtils.cs
+++ b/Backend/Backend/Common/Utilities/JwtUtils.cs
@@ -41,7 +41,8 @@ namespace Backend.Common.Utilities
                 new Claim("Id", user.Id.ToString()),
                 new Claim("Email", user.Email ?? ""),
                 new Claim("UserType", user.UserRole != null ? user.UserRole.ToString() : ""),
-                new Claim("OrgId", user.OrgId != null ? user.OrgId.ToString() : "org is null")
+                new Claim("OrgId", user.OrgId != null ? user.OrgId.ToString() : "org is null"),
+                new Claim("OrgType", user.Organisation.OrganisationType != null ? user.Organisation.OrganisationType :"Unknown")
             };
             var Sectoken = new JwtSecurityToken(this._config["Jwt:Issuer"],
                 this._config["Jwt:Issuer"],


### PR DESCRIPTION
Done for adding organization type inside. Hence, allow user segregation on hotel clients and manufacture which allows them for using the features, API methods and views on flutter only based on their own role and own organization type.