### PR TITLE
Feature/rotation mattress update api

### DIFF
--- a/Backend/Backend/Common/Enums/LogStatus.cs
+++ b/Backend/Backend/Common/Enums/LogStatus.cs
@@ -11,6 +11,7 @@
         damaged = 6,
         disposed = 7,
         AddedMattress = 8,
+        rotated = 10,
         unknown = 9
     }
 }

--- a/Backend/Backend/DTOs/Mattress/MattressDto.cs
+++ b/Backend/Backend/DTOs/Mattress/MattressDto.cs
@@ -15,6 +15,7 @@ namespace Backend.DTOs.Mattress
         public int? Status { get; set; }
         public DateTime? LifeCyclesEnd { get; set; }
         public int? DaysToRotate { get; set; }
+        public DateTime? LatestDateRotate { get; set; }
 
     }
 }

--- a/Backend/Backend/Entities/Mattress.cs
+++ b/Backend/Backend/Entities/Mattress.cs
@@ -17,6 +17,7 @@ namespace MatCron.Backend.Entities
         public DateTime? LifeCyclesEnd { get; set; }  
         public int DaysToRotate { get; set; }  
         public DateTime? RotationTimer { get; set; }
+        public DateTime? LatestDateRotate { get; set; }
 
         // Navigation Properties
         public MattressType MattressType { get; set; }


### PR DESCRIPTION
Now Rotation Mattress able to update when they rotate for the purpose of lifecycle tracking.

**API :** edit mattress api will be the same as it is

> Frontend Input:


```
{
    LatestDateRotate: Datetime
}
```

This will be the input from the frontend. Hence, frontend will just need to add this input field will do .