### PR TITLE
Patch/token unable to retrieve organisation in jwtutills file

### DIFF
--- a/Backend/Backend/Controllers/TestController.cs
+++ b/Backend/Backend/Controllers/TestController.cs
@@ -251,7 +251,7 @@ namespace Backend.Controllers
         {
             try
             {
-                User user = await _context.Users.FirstOrDefaultAsync(u => u.Email == dto.Email);
+                User user = await _context.Users.Include(u => u.Organisation).FirstOrDefaultAsync(u => u.Email == dto.Email);
                 if (user.Token == null)
                 {
                     user.Token = _jwtUtils.GenerateJwtToken(user);

--- a/Backend/Backend/Repositories/AuthRepository.cs
+++ b/Backend/Backend/Repositories/AuthRepository.cs
@@ -62,7 +62,7 @@ namespace MatCron.Backend.Repositories.Implementations
                 JwtUtils agent = new JwtUtils(_config);
 
                 // Step 1: Find user by email
-                User user = await _context.Users.SingleOrDefaultAsync(u => u.Email == dto.Email);
+                User user = await _context.Users.Include(u => u.Organisation).SingleOrDefaultAsync(u => u.Email == dto.Email);
 
                 if (user == null)
                 {


### PR DESCRIPTION
When fetching user data from the db I included organisation. Hence, in the GenerateJwtToken are able to get the organisation data.

> Original:

```csharp
User user = await _context.Users.FirstOrDefaultAsync(u => u.Email == dto.Email);
user.Token = _jwtUtils.GenerateJwtToken(user);
```

> New:
```csharp
User user = await _context.Users.Include(u => u.Organisation).FirstOrDefaultAsync(u => u.Email == dto.Email);
user.Token = _jwtUtils.GenerateJwtToken(user);
```
